### PR TITLE
 improve test coverage and add stack safe versions for transform & flattenTree

### DIFF
--- a/src/main/scala/MapUtils.scala
+++ b/src/main/scala/MapUtils.scala
@@ -1,6 +1,150 @@
 package org.wabase
+import scala.annotation.tailrec
 
 object MapUtils {
+
+  sealed trait TailRec[+A] {
+    @tailrec final def run: A = this match {
+      case Done(a) => a
+      case Call(thunk) => thunk().run
+    }
+
+    def map[B](f: A => B): TailRec[B] = this match {
+      case Done(a) => Done(f(a))
+      case Call(thunk) => Call(() => thunk().map(f))
+    }
+
+    def flatMap[B](f: A => TailRec[B]): TailRec[B] = this match {
+      case Done(a) => f(a)
+      case Call(thunk) => Call(() => thunk().flatMap(f))
+    }
+  }
+
+  case class Done[+A](a: A) extends TailRec[A]
+  case class Call[+A](thunk: () => TailRec[A]) extends TailRec[A]
+
+  def done[A](a: A): TailRec[A] = Done(a)
+  def call[A](thunk: () => TailRec[A]): TailRec[A] = Call(thunk)
+
+  def sequence[A](list: List[TailRec[A]]): TailRec[List[A]] =
+    list.foldRight(Done(List.empty[A]): TailRec[List[A]]) { (currentTrampoline, accTrampoline) =>
+      for {
+        currentResult <- currentTrampoline
+        accumulatedResults <- accTrampoline
+      } yield currentResult :: accumulatedResults
+    }
+
+  def traverse[A, B](list: List[A])(f: A => TailRec[B]): TailRec[List[B]] = {
+    list.foldRight(done(List.empty[B])) { (item, accTailRecList) =>
+      for {
+        b <- f(item)
+        bs <- accTailRecList
+      } yield b :: bs
+    }
+  }
+
+  def transform_ss(path: String, transformVal: Any => Any, map: Map[String, Any]): Map[String, Any] = {
+
+    def transformMapEntriesT(
+                              remainingIterator: Iterator[(String, Any)],
+                              currentPathPrefix: String,
+                              acc: List[(String, Any)] // must be List to avoid Map's recursive additions
+                            ): TailRec[Map[String, Any]] = call(() => {
+      if (remainingIterator.hasNext) {
+        val (k, v) = remainingIterator.next()
+        val fullKeyPath = s"$currentPathPrefix/$k"
+
+        val valueTransformation: TailRec[Any] =
+          if (path == fullKeyPath.stripPrefix("/")) {
+            done(transformVal(v))
+          } else {
+            transformAnyT(v, fullKeyPath)
+          }
+        valueTransformation.flatMap { transformedV =>
+          transformMapEntriesT(
+            remainingIterator,
+            currentPathPrefix,
+            (k -> transformedV) :: acc
+          )
+        }
+      } else {
+        done(acc.reverse.toMap)
+      }
+    })
+
+    def transformAnyT(currentValue: Any, currentPathPrefix: String): TailRec[Any] = call(() => {
+      // The `call` here ensures -- body is evaluated lazily.
+      currentValue match {
+        case m: Map[String, Any] @unchecked =>
+          transformMapEntriesT(m.iterator, currentPathPrefix, List.empty[(String, Any)])
+
+        case l: List[Map[String, Any] @unchecked] =>
+          // Use 'traverse' to process each inner map in the list in a stack-safe manner.
+          traverse(l) { innerMap =>
+            transformAnyT(innerMap, currentPathPrefix).map(_.asInstanceOf[Map[String, Any]])
+          }
+
+        case other =>
+          // If it's not a Map or List[Map], return the value wrapped in Done.
+          done(other)
+      }
+    })
+
+    transformAnyT(map, "").run.asInstanceOf[Map[String, Any]]
+  }
+
+  def flattenTree_ss(map: Map[String, Any], keyFields: List[String] = Nil): Map[List[Any], Any] = {
+
+    def getKey(v: Any, index: Int): Any = v match {
+      case m: Map[String, Any] @unchecked if keyFields.exists(m.contains) =>
+        keyFields.find(m.contains).map(s => m(s)).get
+      case _ if keyFields.contains("#index") => index
+      case a => a.hashCode
+    }
+
+    def flatenMapEntriesAccumulatorT(
+                                      remainingIterator: Iterator[(String, Any)],
+                                      accMaps: List[Map[List[Any], Any]]
+                                    ): TailRec[Map[List[Any], Any]] = call(() => {
+      if (remainingIterator.hasNext) {
+        val (k, v) = remainingIterator.next()
+        flatenValueT(v).flatMap { innerFlattenedMap =>
+          val transformedInner = innerFlattenedMap.map { case (path, value) =>
+            (k :: path, value)
+          }
+          flatenMapEntriesAccumulatorT(remainingIterator, transformedInner :: accMaps)
+        }
+      } else {
+        Done(accMaps.flatMap(identity).toMap)
+      }
+    })
+
+    def flatenValueT(v: Any): TailRec[Map[List[Any], Any]] = call(() => {
+      v match {
+        case m: Map[String, Any] @unchecked =>
+          // For maps, use the `flatenMapEntriesAccumulatorT` to process entries stack-safely.
+          flatenMapEntriesAccumulatorT(m.iterator, List.empty)
+
+        case l: List[Any] @unchecked =>
+          // For lists, use the general `traverse` function for stack-safe iteration.
+          traverse(l.zipWithIndex.toList) { case (item, idx) =>
+            val itemKey = getKey(item, idx)
+            flatenValueT(item).map { innerFlattenedMap =>
+              innerFlattenedMap.map { case (path, value) =>
+                (itemKey :: path, value)
+              }
+            }
+          }.map { listOfMaps =>
+            listOfMaps.flatMap(identity).toMap
+          }
+
+        case a => done(Map(Nil -> a))
+      }
+    })
+
+    flatenValueT(map).run
+  }
+
   def transform(path: String, transformVal: Any => Any, map: Map[String, Any]): Map[String, Any] = {
     def transform(
         path: String,

--- a/src/test/resources/querease-action-specs-metadata.yaml
+++ b/src/test/resources/querease-action-specs-metadata.yaml
@@ -82,8 +82,8 @@ columns:
 
 table: if_and_foreach_test
 columns:
-- code                ! 40
-- parent                40
+- code                ! 90000
+- parent                90000
 - value                 64
 
 table: simple_table

--- a/src/test/resources/querease-action-specs-metadata.yaml
+++ b/src/test/resources/querease-action-specs-metadata.yaml
@@ -1593,3 +1593,42 @@ list:
 insert:
 - arr = {'jasmine' name, |[({'guest'} + {'admin'})#(1)] 'roles'} # alias roles must be put in quotes so it is not taken for table name
 - as any :arr
+
+  # YAML designed to bypass processView cycle detection by alternating action names
+name: view_cycle_A
+table:
+api: save, get
+fields:
+  - id_a
+  - data_a
+save:
+  - insert view_cycle_B
+get:
+  - update view_cycle_B
+
+name: view_cycle_B
+table:
+api: insert, update
+fields:
+  - id_b
+  - data_b
+insert:
+  - get view_cycle_A
+update:
+  - save view_cycle_A
+
+name: exploit_trigger
+table:
+api: get, list, save
+fields:
+- trigger_status
+get:
+  - unique {:id id_a, :data data_a}
+list:
+- res = http '/view_cycle_A'
+- status ok :res
+insert:
+- res = http post [default-wabase-http-client] '/view_cycle_A'
+         unique { 'start_id' id_a, 'trigger_data' data_a }
+         []
+- status ok :res

--- a/src/test/scala/MapDiffTests.scala
+++ b/src/test/scala/MapDiffTests.scala
@@ -10,20 +10,238 @@ class MapDiffTests extends FlatSpec with Matchers {
 
   "flattenTree" should "work" in {
     flattenTree(Map()) should be(Map())
-    flattenTree(Map("a"->"b")) should be(Map(List("a")->"b"))
-    flattenTree(Map("a"->"b","c"->"d")) should be(Map(List("a")->"b",List("c")->"d"))
-    flattenTree(Map("a"->1)) should be(Map(List("a")->1))
+    flattenTree(Map("a" -> "b")) should be(Map(List("a") -> "b"))
+    flattenTree(Map("a" -> "b", "c" -> "d")) should be(Map(List("a") -> "b", List("c") -> "d"))
+    flattenTree(Map("a" -> 1)) should be(Map(List("a") -> 1))
 
-    flattenTree(Map("a"->Map("b"->"c"))) should be(Map(List("a","b")->"c"))
-    flattenTree(Map("a"->Map("b"->"c"),"c"->"d")) should be(Map(List("a","b")->"c",List("c")->"d"))
-    flattenTree(Map("a"->Map("b"-> Map("c"->"f")),"c"->"d")) should be(Map(List("a","b","c")->"f",List("c")->"d"))
+    flattenTree(Map("a" -> Map("b" -> "c"))) should be(Map(List("a", "b") -> "c"))
+    flattenTree(Map("a" -> Map("b" -> "c"), "c" -> "d")) should be(Map(List("a", "b") -> "c", List("c") -> "d"))
+    flattenTree(Map("a" -> Map("b" -> Map("c" -> "f")), "c" -> "d")) should be(Map(List("a", "b", "c") -> "f", List("c") -> "d"))
 
-    flattenTree(Map("a"->List("b"))) should be(Map(List("a",98)->"b"))
-    flattenTree(Map("a"->List("b", "c"))) should be(Map(List("a",98)->"b",List("a",99)->"c"))
-    val hash = Map("b"->"c", "m"->"n").hashCode()
-    flattenTree(Map("a"->List(Map("b"->"c", "m"->"n")))) should be(Map(List("a",hash,"b")->"c",List("a",hash,"m")->"n"))
-    flattenTree(Map("i" ->Map("a"->List(Map("b"->"c", "m"->"n"))))) should be(Map(List("i","a",hash,"b")->"c",List("i","a",hash,"m")->"n"))
+    flattenTree(Map("a" -> List("b"))) should be(Map(List("a", 98) -> "b"))
+    flattenTree(Map("a" -> List("b", "c"))) should be(Map(List("a", 98) -> "b", List("a", 99) -> "c"))
+    val hash = Map("b" -> "c", "m" -> "n").hashCode()
+    flattenTree(Map("a" -> List(Map("b" -> "c", "m" -> "n")))) should be(Map(List("a", hash, "b") -> "c", List("a", hash, "m") -> "n"))
+    flattenTree(Map("i" -> Map("a" -> List(Map("b" -> "c", "m" -> "n"))))) should be(Map(List("i", "a", hash, "b") -> "c", List("i", "a", hash, "m") -> "n"))
   }
+    "The flattenTree function" should "never throw StackOverflowError when given a very deep nested map or list" in {
+
+      val testCapabilityDepth = 10000
+      val constructionDepth = 5000 // A value that should not cause SOE during Map construction
+      info(s"flattenTree_ss Deep Map Test: Construction Depth $constructionDepth, Testing Function Capability up to $testCapabilityDepth")
+      val innermostLeafMap: Map[String, Any] = Map("key" -> "leaf_value")
+      val actualDeepMap: Map[String, Any] = (1 to constructionDepth - 1).foldLeft(innermostLeafMap) { (acc, _) =>
+        Map("key" -> acc)
+      }
+
+      try {
+        val expectedPathForDeepMap = List.fill(constructionDepth)("key")
+        val expectedDeepMapResult = Map(expectedPathForDeepMap -> "leaf_value")
+
+        flattenTree(actualDeepMap) should be(expectedDeepMapResult)
+        info(s"Deep map flattenTree with construction depth $constructionDepth did not trigger stack overflow and produced expected result.")
+        succeed
+      } catch {
+        case e: StackOverflowError => fail("Unexpected StackOverflowError for deep map: " + e.getMessage)
+        case e: Exception => fail(s"Unexpected exception for deep map: ${e.getMessage}")
+      }
+
+      info(s"flattenTree Deep List of Maps Test: Construction Depth $constructionDepth, Testing Function Capability up to $testCapabilityDepth")
+      val innermostList: List[Map[String, Any]] = List(Map("item1" -> "val1"), Map("item2" -> "val2"))
+      val actualDeepListMapInput: Map[String, Any] = (1 to constructionDepth).foldLeft(innermostList: Any) { (acc: Any, i) =>
+        Map(s"key_$i" -> acc)
+      }.asInstanceOf[Map[String, Any]]
+
+      try {
+        val result = flattenTree(actualDeepListMapInput, List("#index"))
+        info(s"Deep list of maps (as leaf of deep map) flattenTree with construction depth $constructionDepth did not trigger stack overflow. Result size: ${result.size}")
+        succeed
+      } catch {
+        case e: StackOverflowError => fail("Unexpected StackOverflowError for deep list of maps (as leaf): " + e.getMessage)
+        case e: Exception => fail(s"Unexpected exception for deep list of maps (as leaf): ${e.getMessage}")
+      }
+
+      info(s"flattenTree Deep List of Primitives Test: Construction Depth $constructionDepth, Testing Function Capability up to $testCapabilityDepth")
+      val deepListPrimitives: List[Any] = (1 to constructionDepth).toList
+      val rootMapForList = Map("numbers" -> deepListPrimitives)
+      try {
+        val result = flattenTree(rootMapForList, List("#index"))
+        info(s"Deep list of primitives flattenTree with construction depth $constructionDepth did not trigger stack overflow. Result size: ${result.size}")
+        succeed
+      } catch {
+        case e: StackOverflowError => fail("Unexpected StackOverflowError for deep list of primitives: " + e.getMessage)
+        case e: Exception => fail(s"Unexpected exception for deep list of primitives: ${e.getMessage}")
+      }
+    }
+
+  "The flattenTree_ss function" should "work with various map and list structures and keying strategies" in {
+    // Test Case 1: Empty map
+    info("flattenTree_ss Test Case 1: Empty map")
+    flattenTree_ss(Map()) should be(Map())
+
+    // Test Case 2: Single key-value pair
+    info("flattenTree_ss Test Case 2: Single key-value pair")
+    flattenTree_ss(Map("a"->"b")) should be(Map(List("a")->"b"))
+
+    // Test Case 3: Multiple key-value pairs at the root
+    info("flattenTree_ss Test Case 3: Multiple key-value pairs at root")
+    flattenTree_ss(Map("a"->"b","c"->"d")) should be(Map(List("a")->"b",List("c")->"d"))
+
+    // Test Case 4: Single integer value
+    info("flattenTree_ss Test Case 4: Single integer value")
+    flattenTree_ss(Map("a"->1)) should be(Map(List("a")->1))
+
+    // Test Case 5: Simple nested map
+    info("flattenTree_ss Test Case 5: Simple nested map")
+    flattenTree_ss(Map("a"->Map("b"->"c"))) should be(Map(List("a","b")->"c"))
+
+    // Test Case 6: Nested map with a sibling key
+    info("flattenTree_ss Test Case 6: Nested map with a sibling key")
+    flattenTree_ss(Map("a"->Map("b"->"c"),"c"->"d")) should be(Map(List("a","b")->"c",List("c")->"d"))
+
+    // Test Case 7: Deeply nested map with a sibling key
+    info("flattenTree_ss Test Case 7: Deeply nested map with a sibling key")
+    flattenTree_ss(Map("a"->Map("b"-> Map("c"->"f")),"c"->"d")) should be(Map(List("a","b","c")->"f",List("c")->"d"))
+
+    // Test Case 8: List containing a single primitive value (default keyFields: hashCode)
+    info("flattenTree_ss Test Case 8: List with single primitive (hashCode key)")
+    flattenTree_ss(Map("a"->List("b"))) should be(Map(List("a","b".hashCode())->"b"))
+
+    // Test Case 9: List containing multiple primitive values (default keyFields: hashCode)
+    info("flattenTree_ss Test Case 9: List with multiple primitives (hashCode keys)")
+    flattenTree_ss(Map("a"->List("b", "c"))) should be(Map(List("a","b".hashCode())->"b",List("a","c".hashCode())->"c"))
+
+    // Test Case 10: List containing a nested map (default keyFields: hashCode for map object)
+    info("flattenTree_ss Test Case 10: List with nested map (hashCode key for map)")
+    val nestedMap1 = Map("b"->"c", "m"->"n")
+    flattenTree_ss(Map("a"->List(nestedMap1))) should be(Map(List("a", nestedMap1.hashCode(),"b")->"c",List("a", nestedMap1.hashCode(),"m")->"n"))
+
+    // Test Case 11: Deeply nested structure involving maps and lists (default keyFields: hashCode)
+    info("flattenTree_ss Test Case 11: Deeply nested map-list structure (hashCode keys)")
+    val nestedMap2 = Map("b"->"c", "m"->"n")
+    flattenTree_ss(Map("i" ->Map("a"->List(nestedMap2)))) should be(Map(List("i","a",nestedMap2.hashCode(),"b")->"c",List("i","a",nestedMap2.hashCode(),"m")->"n"))
+
+    // 12. List with "#index" in keyFields
+    info("flattenTree_ss Test Case 12: List with '#index' in keyFields")
+    flattenTree_ss(Map("items" -> List("apple", "banana")), List("#index")) should be(
+      Map(List("items", 0) -> "apple", List("items", 1) -> "banana")
+    )
+
+    // 13. List of maps with specified keyFields for inner maps
+    info("flattenTree_ss Test Case 13: List of maps with specific 'id' keyField")
+    flattenTree_ss(Map("users" -> List(Map("id" -> 1, "name" -> "Alice"), Map("id" -> 2, "name" -> "Bob"))), List("id")) should be(
+      Map(
+        List("users", 1, "id") -> 1, List("users", 1, "name") -> "Alice",
+        List("users", 2, "id") -> 2, List("users", 2, "name") -> "Bob"
+      )
+    )
+
+    // 14. List of maps with mixed `keyFields` (id and #index)
+    info("flattenTree_ss Test Case 14: List of maps with 'id' and '#index' keyFields")
+    flattenTree_ss(Map("data" -> List(Map("value" -> "a"), Map("id" -> "x", "value" -> "b"))), List("id", "#index")) should be(
+      Map(
+        List("data", 0, "value") -> "a", // "id" not found, falls back to #index (0)
+        List("data", "x", "id") -> "x", List("data", "x", "value") -> "b" // "id" found as "x"
+      )
+    )
+
+    // 15. Empty nested map
+    info("flattenTree_ss Test Case 15: Empty nested map")
+    flattenTree_ss(Map("config" -> Map.empty[String, Any])) should be(Map())
+
+    // 16. Empty list
+    info("flattenTree_ss Test Case 16: Empty list")
+    flattenTree_ss(Map("items" -> List.empty[Any])) should be(Map())
+
+    // 17. Map with non-collection value directly
+    info("flattenTree_ss Test Case 17: Map with primitive value")
+    flattenTree_ss(Map("status" -> true)) should be(Map(List("status") -> true))
+
+    // 18. Complex nested structure with mixed types and keying
+    info("flattenTree_ss Test Case 18: Complex nested structure with mixed types and keying")
+    val complexMap = Map(
+      "books" -> List(
+        Map("isbn" -> "123", "title" -> "Book A", "authors" -> List(Map("name" -> "Author1"))),
+        Map("isbn" -> "456", "title" -> "Book B")
+      ),
+      "version" -> 1.0
+    )
+    val complexKeyFields = List("isbn", "name", "#index")
+    val expectedComplex = Map(
+      List("books", "123", "isbn") -> "123",
+      List("books", "123", "title") -> "Book A",
+      List("books", "123", "authors", "Author1", "name") -> "Author1",
+      List("books", "456", "isbn") -> "456",
+      List("books", "456", "title") -> "Book B",
+      List("version") -> 1.0
+    )
+    flattenTree_ss(complexMap, complexKeyFields) should be(expectedComplex)
+
+
+    // 19. TODO
+
+    // 20. Value is null at a leaf node
+    info("flattenTree_ss Test Case 20: Null value at leaf node")
+    flattenTree_ss(Map("settings" -> Map("timeout" -> null))) should be(Map(List("settings", "timeout") -> null))
+
+    // 21. Value is None at a leaf node
+    info("flattenTree_ss Test Case 21: None value at leaf node")
+    flattenTree_ss(Map("data" -> Map("optional_field" -> None))) should be(Map(List("data", "optional_field") -> None))
+  }
+
+  "The flattenTree_ss function" should "never throw StackOverflowError when given a very deep nested map or list" in {
+
+    val testCapabilityDepth = 10000
+
+    val constructionDepth = 5000
+    info(s"flattenTree_ss Deep Map Test: Construction Depth $constructionDepth, Testing Function Capability up to $testCapabilityDepth")
+    // Explicitly define type to prevent type inference issues during folding
+    val innermostLeafMap: Map[String, Any] = Map("key" -> "leaf_value")
+    val actualDeepMap: Map[String, Any] = (1 to constructionDepth - 1).foldLeft(innermostLeafMap) { (acc, _) =>
+      Map("key" -> acc)
+    }
+
+    try {
+      val expectedPathForDeepMap = List.fill(constructionDepth)("key")
+      val expectedDeepMapResult = Map(expectedPathForDeepMap -> "leaf_value")
+
+      flattenTree_ss(actualDeepMap) should be(expectedDeepMapResult)
+      info(s"Deep map flattenTree_ss with construction depth $constructionDepth did not trigger stack overflow and produced expected result.")
+      succeed
+    } catch {
+      case e: StackOverflowError => fail("Unexpected StackOverflowError for deep map: " + e.getMessage)
+      case e: Exception => fail(s"Unexpected exception for deep map: ${e.getMessage}")
+    }
+
+    // iteratively to avoid SOE during setup
+    info(s"flattenTree_ss Deep List of Maps Test: Construction Depth $constructionDepth, Testing Function Capability up to $testCapabilityDepth")
+    val innermostList: List[Map[String, Any]] = List(Map("item1" -> "val1"), Map("item2" -> "val2"))
+    val actualDeepListMapInput: Map[String, Any] = (1 to constructionDepth).foldLeft(innermostList: Any) { (acc: Any, i) =>
+      Map(s"key_$i" -> acc)
+    }.asInstanceOf[Map[String, Any]]
+
+    try {
+      val result = flattenTree_ss(actualDeepListMapInput, List("#index"))
+      info(s"Deep list of maps (as leaf of deep map) flattenTree_ss with construction depth $constructionDepth did not trigger stack overflow. Result size: ${result.size}")
+      succeed
+    } catch {
+      case e: StackOverflowError => fail("Unexpected StackOverflowError for deep list of maps (as leaf): " + e.getMessage)
+      case e: Exception => fail(s"Unexpected exception for deep list of maps (as leaf): ${e.getMessage}")
+    }
+
+    info(s"flattenTree_ss Deep List of Primitives Test: Construction Depth $constructionDepth, Testing Function Capability up to $testCapabilityDepth")
+    val deepListPrimitives: List[Any] = (1 to constructionDepth).toList
+    val rootMapForList = Map("numbers" -> deepListPrimitives)
+    try {
+      val result = flattenTree_ss(rootMapForList, List("#index"))
+      info(s"Deep list of primitives flattenTree_ss with construction depth $constructionDepth did not trigger stack overflow. Result size: ${result.size}")
+      succeed
+    } catch {
+      case e: StackOverflowError => fail("Unexpected StackOverflowError for deep list of primitives: " + e.getMessage)
+      case e: Exception => fail(s"Unexpected exception for deep list of primitives: ${e.getMessage}")
+    }
+  }
+
 
   "zipMaps" should "work" in {
     zipMaps(Map(),Map()) should be(Map())

--- a/src/test/scala/RecFunctionTests.scala
+++ b/src/test/scala/RecFunctionTests.scala
@@ -1,0 +1,47 @@
+package org.wabase
+
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.wabase.MapUtils._
+import scala.annotation.tailrec
+import scala.util.control.TailCalls._
+import scala.language.postfixOps
+
+class RecFunctionTests extends AnyFlatSpec {
+
+  "The transform function" should "throw a StackOverflowError when given a very deep nested map" in {
+    val path = ""
+    val transformVal: Any => Any = identity
+    val depth = 5999 //value to trigger the stack overflow error
+    var map: Map[String, Any] = Map.empty
+    (1 to depth).foreach { _ =>
+      map = Map("key" -> map)
+    }
+    try {
+      transform(path, transformVal, map)
+      fail("Expected a StackOverflowError but none was thrown")
+    } catch {
+      case e: StackOverflowError => succeed
+    }
+  }
+
+
+  "The transform_ss function" should "never throw StackOverflowError when given a very deep nested map" in {
+    val path = ""
+    val transformVal: Any => Any = identity
+    val depth = 10000 //value to trigger the stack overflow error
+    var map: Map[String, Any] = Map.empty
+    (1 to depth).foreach { _ =>
+      map = Map("key" -> map)
+    }
+    try {
+      transform_ss(path, transformVal, map)
+      info("path depth of 10000 did not trigger stack overflow")
+      succeed
+    } catch {
+      case e: StackOverflowError => fail("Unexpected StackOverflowError")
+    }
+  }
+
+}
+

--- a/src/test/scala/TransformTests.scala
+++ b/src/test/scala/TransformTests.scala
@@ -1,0 +1,123 @@
+package org.wabase
+
+import MapUtils._
+
+import org.scalatest.flatspec.{AnyFlatSpec => FlatSpec}
+import org.scalatest.matchers.should.Matchers
+
+
+class TransformTests extends FlatSpec with Matchers {
+
+
+  "transform" should "work" in {
+
+    transform("", identity, Map()) should be(Map())
+
+    transform("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> Map("c" -> "y")))) should be(Map("a" -> Map("b" -> Map("c" -> "x"))))
+
+    transform("a/b/c/d", (_: Any) => "x", Map("a" -> Map("b" -> Map("c" -> Map("d" -> "y"))))) should be(Map("a" -> Map("b" -> Map("c" -> Map("d" -> "x")))))
+
+    transform("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> List(Map("c" -> "y"), Map("c" -> "z"))))) should be(
+      Map("a" -> Map("b" -> List(Map("c" -> "x"), Map("c" -> "x"))))
+    )
+    transform("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> Map("d" -> "y")))) should be(
+      Map("a" -> Map("b" -> Map("d" -> "y")))
+    )
+
+    transform("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> List(Map("c"->"d", "e"->"f"), Map("g"->"h"))))) should be(
+      Map("a" -> Map("b" -> List(Map("c" -> "x", "e" -> "f"), Map("g" -> "h"))))
+    )
+
+    transform("", (_: Any) => "x", Map()) should be(Map())
+  }
+
+  "The transform_ss function" should "work with various map structures and paths" in {
+    // Test Case 1: Empty map and empty path - should return an empty map
+    info("Test Case 1: Empty map and empty path")
+    transform_ss("", identity, Map()) should be(Map())
+
+    // Test Case 2: Simple transformation of a single value at a specific path
+    info("Test Case 2: Simple transformation of a single value")
+    transform_ss("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> Map("c" -> "y")))) should be(Map("a" -> Map("b" -> Map("c" -> "x"))))
+
+    // Test Case 3: Transformation of a deeper nested map structure
+    info("Test Case 3: Transformation of a deeper nested map structure")
+    transform_ss("a/b/c/d", (_: Any) => "x", Map("a" -> Map("b" -> Map("c" -> Map("d" -> "y"))))) should be(Map("a" -> Map("b" -> Map("c" -> Map("d" -> "x")))))
+
+    // Test Case 4: Transformation of values within a list of maps
+    info("Test Case 4: Transformation of values within a list of maps")
+    transform_ss("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> List(Map("c" -> "y"), Map("c" -> "z"))))) should be(
+      Map("a" -> Map("b" -> List(Map("c" -> "x"), Map("c" -> "x"))))
+    )
+
+    // Test Case 5: Path does not match any existing key - no change expected
+    info("Test Case 5: Ignore paths that don't match")
+    transform_ss("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> Map("d" -> "y")))) should be(
+      Map("a" -> Map("b" -> Map("d" -> "y")))
+    )
+
+    // Test Case 6: Transformation within a list of maps where some maps might not have the target key
+    info("Test Case 6: Transformation in list of maps, with mixed matching/non-matching inner maps")
+    transform_ss("a/b/c", (_: Any) => "x", Map("a" -> Map("b" -> List(Map("c"->"d", "e"->"f"), Map("g"->"h"))))) should be(
+      Map("a" -> Map("b" -> List(Map("c" -> "x", "e" -> "f"), Map("g" -> "h"))))
+    )
+
+    // Test Case 7: Transforming a root-level key
+    info("Test Case 7: Transforming a root-level key")
+    transform_ss("root_key", (_: Any) => "new_value", Map("root_key" -> "old_value", "other_key" -> 123)) should be(
+      Map("root_key" -> "new_value", "other_key" -> 123)
+    )
+
+    // Test Case 8: Path not found at any level (no change expected), more complex map
+    info("Test Case 8: Path not found at any level (no change expected)")
+    transform_ss("non_existent/path/to/value", (_: Any) => "transformed", Map("a" -> Map("b" -> "c"))) should be(
+      Map("a" -> Map("b" -> "c"))
+    )
+
+    // Test Case 9: Transformation of a value to a different type
+    info("Test Case 9: Transformation of a value to a different type")
+    transform_ss("data/value", (_: Any) => 123.45, Map("data" -> Map("value" -> "hello"))) should be(
+      Map("data" -> Map("value" -> 123.45))
+    )
+
+    // Test Case 10: Path leads through a list, but the target key is missing in some maps within the list
+    info("Test Case 10: Path through list, target key missing in some inner maps")
+    transform_ss("list_of_maps/target_key", (_: Any) => true,
+      Map("list_of_maps" -> List(
+        Map("other_key" -> 1, "target_key" -> false),
+        Map("another_map_key" -> "abc"), // target_key is missing here
+        Map("target_key" -> "maybe")
+      ))
+    ) should be(
+      Map("list_of_maps" -> List(
+        Map("other_key" -> 1, "target_key" -> true),
+        Map("another_map_key" -> "abc"),
+        Map("target_key" -> true)
+      ))
+    )
+
+    // Test Case 11: Path points to a non-map/list value mid-way
+    info("Test Case 11: Path points to non-map/list value mid-way")
+    transform_ss("a/b/c/d", (_: Any) => "x", Map("a" -> Map("b" -> "not_a_map"))) should be(
+      Map("a" -> Map("b" -> "not_a_map"))
+    )
+
+    // Test Case 12: Transforming a null value
+    info("Test Case 12: Transforming a null value")
+    transform_ss("config/param", (_: Any) => "default", Map("config" -> Map("param" -> null))) should be(
+      Map("config" -> Map("param" -> "default"))
+    )
+
+    // Test Case 13: Transforming a None value
+    info("Test Case 13: Transforming a None value")
+    transform_ss("config/param", (_: Any) => "default", Map("config" -> Map("param" -> None))) should be(
+      Map("config" -> Map("param" -> "default"))
+    )
+
+    // Test Case 14: Empty map within the path
+    info("Test Case 14: Empty intermediate map")
+    transform_ss("level1/level2/value", (_:Any) => 999, Map("level1" -> Map("level2" -> Map()))) should be(
+      Map("level1" -> Map("level2" -> Map()))
+    )
+  }
+}

--- a/src/test/scala/WabaseActionsSpecs.scala
+++ b/src/test/scala/WabaseActionsSpecs.scala
@@ -883,7 +883,7 @@ class WabaseActionsSpecs extends AsyncFlatSpec with Matchers with TestQuereaseIn
         }
       }
   }
-
+  
   it should "remove field from data set" in {
     for {
       t1 <- doAction("insert", "remove_var_test", Map("var1" -> "data1", "var2" -> "data2"))
@@ -1664,4 +1664,12 @@ class WabaseActionsSpecs extends AsyncFlatSpec with Matchers with TestQuereaseIn
         .map(_ shouldBe List(Map("name" -> "jasmine", "roles" -> List("admin", "guest"))))
     } yield t1
   }
+  
+  it should "handle cycles in prcessView correctly" in {
+    for {
+      t <- doAction("insert", "exploit_trigger", Map())
+        .map { _ shouldBe ResponseResult(200, ResultValue(StringResult("ok"))) }
+    } yield t
+  }
+    
 }

--- a/src/test/scala/WabaseActionsSpecs.scala
+++ b/src/test/scala/WabaseActionsSpecs.scala
@@ -1671,5 +1671,53 @@ class WabaseActionsSpecs extends AsyncFlatSpec with Matchers with TestQuereaseIn
         .map { _ shouldBe ResponseResult(200, ResultValue(StringResult("ok"))) }
     } yield t
   }
-    
+
+  
+  val TestTimeout: FiniteDuration = 30.seconds
+  private def createNestedChildrenData(currentDepth: Int, maxDepth: Int, parentCode: String): List[Map[String, Any]] = {
+    if (currentDepth > maxDepth) {
+      List.empty[Map[String, Any]]
+    } else {
+      val childCode = s"${parentCode}.ch_${currentDepth}"
+      List(
+        Map(
+          "code" -> childCode,
+          "value" -> s"ch_val_${currentDepth}",
+          "children" -> createNestedChildrenData(currentDepth + 1, maxDepth, childCode)
+        )
+      )
+    }
+  }
+
+  private def createDeepInputMap(depth: Int): Map[String, Any] = {
+    val rootCode = "r"
+    Map(
+      "code" -> rootCode,
+      "value" -> "top_level",
+      "children" -> createNestedChildrenData(1, depth, rootCode) 
+    )
+  }
+
+  behavior of "Save operation with dynamically generated deep nesting"
+
+  it should "attempt to process a very deep structure and observe behavior" in {
+    val nestingDepth = 3000
+    val deepInput = createDeepInputMap(nestingDepth)
+
+    info(s"Attempting save with nesting depth: $nestingDepth (expect potential SOE or timeout)")
+    val resultFuture = doAction("save", "foreach_test_1", deepInput)
+
+    try {
+      val result = Await.result(resultFuture, TestTimeout)
+      info(s"Successfully processed very deep nesting ($nestingDepth) without SOE.")
+      result shouldBe a [Map[_, _]]
+    } catch {
+      case e: StackOverflowError =>
+        println(s"Caught expected SOE for depth $nestingDepth: ${e.getMessage}")
+        succeed // Test passes --> SOE was caught
+      case ex: Throwable =>
+        fail(s"Unexpected error occurred: ${ex.getMessage}", ex)
+    }
+  }
+
 }


### PR DESCRIPTION
stack safe functions are with _ss in name. Original functions are left as is for now.
Tests demonstrate SOE with existing unsafe approach to coding.